### PR TITLE
Update 좋아요 증가/감소 API URI

### DIFF
--- a/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
+++ b/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
@@ -58,7 +58,7 @@ public class UncomfortableController {
      * @return getSuccessResult
      * @author 전지환, 정시원
      */
-    @PatchMapping("/uncomfortable/like/increase/{uncomfortableIdx}")
+    @PatchMapping("/uncomfortable/{uncomfortableIdx}/increase")
     public CommonResult increaseLike(@PathVariable Long uncomfortableIdx){
         uncomfortableService.increaseLike(uncomfortableIdx);
         return responseService.getSuccessResult();
@@ -70,7 +70,7 @@ public class UncomfortableController {
      * @return getSuccessResult
      * @author 전지환, 정시원
      */
-    @PatchMapping("/uncomfortable/like/decrease/{uncomfortableIdx}")
+    @PatchMapping("/uncomfortable/{uncomfortableIdx}/decrease")
     public CommonResult decreaseLike(@PathVariable Long uncomfortableIdx){
         uncomfortableService.decreaseLike(uncomfortableIdx);
         return responseService.getSuccessResult();

--- a/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
+++ b/src/main/java/com/moment/the/uncomfortable/controller/UncomfortableController.java
@@ -58,7 +58,7 @@ public class UncomfortableController {
      * @return getSuccessResult
      * @author 전지환, 정시원
      */
-    @PatchMapping("/uncomfortable/{uncomfortableIdx}/increase")
+    @PatchMapping("/uncomfortable/{uncomfortableIdx}/like-increase")
     public CommonResult increaseLike(@PathVariable Long uncomfortableIdx){
         uncomfortableService.increaseLike(uncomfortableIdx);
         return responseService.getSuccessResult();
@@ -70,7 +70,7 @@ public class UncomfortableController {
      * @return getSuccessResult
      * @author 전지환, 정시원
      */
-    @PatchMapping("/uncomfortable/{uncomfortableIdx}/decrease")
+    @PatchMapping("/uncomfortable/{uncomfortableIdx}/like-decrease")
     public CommonResult decreaseLike(@PathVariable Long uncomfortableIdx){
         uncomfortableService.decreaseLike(uncomfortableIdx);
         return responseService.getSuccessResult();

--- a/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
+++ b/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
@@ -159,7 +159,7 @@ class UncomfortableControllerTest {
 
         //When
         resultActions = mockMvc.perform(
-                patch("/v1/uncomfortable/"+uncomfortableIdx+"/increase")
+                patch("/v1/uncomfortable/"+uncomfortableIdx+"/like-increase")
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -181,7 +181,7 @@ class UncomfortableControllerTest {
 
         //When
         resultActions = mockMvc.perform(
-                patch("/v1/uncomfortable/"+uncomfortableIdx+"/decrease")
+                patch("/v1/uncomfortable/"+uncomfortableIdx+"/like-decrease")
                         .contentType(MediaType.APPLICATION_JSON)
         );
 

--- a/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
+++ b/src/test/java/com/moment/the/controller/release/UncomfortableControllerTest.java
@@ -159,7 +159,7 @@ class UncomfortableControllerTest {
 
         //When
         resultActions = mockMvc.perform(
-                patch("/v1/uncomfortable/like/increase/" + uncomfortableIdx)
+                patch("/v1/uncomfortable/"+uncomfortableIdx+"/increase")
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -181,7 +181,7 @@ class UncomfortableControllerTest {
 
         //When
         resultActions = mockMvc.perform(
-                patch("/v1/uncomfortable/like/decrease/" + uncomfortableIdx)
+                patch("/v1/uncomfortable/"+uncomfortableIdx+"/decrease")
                         .contentType(MediaType.APPLICATION_JSON)
         );
 


### PR DESCRIPTION
## 개요
커밋참고 좋아요 증가/감소 API URI 변경 됨.
HTTP method patch 가 증가/감소를 구분하는데 한계가 있기에 "컨트롤 URI"로 업데이트함.

## 참고
HTTP URI 설계 원칙을 따르면
* URI를 매핑하실때 주의하세요, URI 는 리소스만 식별하면 됩니다. (행위는 HTTP method 가 합니다.)
* HTTP 메소드로 나타낼 수 있는 행위가 2개 이상의 API와 겹치는 상황에 극한하여 사용합니다. (보수적으로 사용)

## 홍보
<img width="600" alt="Screen Shot 2021-12-09 at 11 47 17 AM" src="https://user-images.githubusercontent.com/67095821/145325358-e1e92027-4cd8-48a4-8fa4-19138c614d6b.png">

