### PR TITLE
Feature/util [현재 회원 엔티티, 이메일 가져오기]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
     implementation 'io.swagger:swagger-annotations:1.6.2'
     implementation 'io.swagger:swagger-models:1.6.2'
 
+    // *** querydsl *** //
+    implementation 'com.querydsl:querydsl-jpa'
+
+    // *** AOP *** //
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // JWT토큰 관련 의존성
     implementation 'io.jsonwebtoken:jjwt-api:0.11.1'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.1'
@@ -63,9 +69,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params'
 
     compileOnly 'org.springframework.boot:spring-boot-starter-tomcat'
-
-    // *** querydsl *** //
-    implementation 'com.querydsl:querydsl-jpa'
 }
 
 //querydsl

--- a/src/main/java/com/moment/the/util/AppUtil.java
+++ b/src/main/java/com/moment/the/util/AppUtil.java
@@ -1,0 +1,2 @@
+package com.moment.the.util;public class AppUtil {
+}

--- a/src/main/java/com/moment/the/util/AppUtil.java
+++ b/src/main/java/com/moment/the/util/AppUtil.java
@@ -7,6 +7,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+/**
+ * 애플리케이션에서 빈번히 발생하는 작업에 대해 Bean으로 등록하여 사용할 수 있습니다.
+ *
+ * @since 1.3.1
+ * @author 전지환
+ */
 @Component
 @RequiredArgsConstructor
 public class AppUtil {

--- a/src/main/java/com/moment/the/util/AppUtil.java
+++ b/src/main/java/com/moment/the/util/AppUtil.java
@@ -1,2 +1,30 @@
-package com.moment.the.util;public class AppUtil {
+package com.moment.the.util;
+
+import com.moment.the.admin.AdminDomain;
+import com.moment.the.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AppUtil {
+
+    private final AdminRepository adminRepository;
+
+    public static String getCurrentAdminEmail(){
+        String userEmail;
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if(principal instanceof UserDetails) {
+            userEmail = ((UserDetails) principal).getUsername();
+        } else {
+            userEmail = principal.toString();
+        }
+        return userEmail;
+    }
+
+    public AdminDomain getCurrentAdminEntity(){
+        return adminRepository.findByEmail(getCurrentAdminEmail());
+    }
 }

--- a/src/test/java/com/moment/the/testConfig/AdminLoginAop.java
+++ b/src/test/java/com/moment/the/testConfig/AdminLoginAop.java
@@ -1,0 +1,66 @@
+package com.moment.the.testConfig;
+
+import com.moment.the.admin.AdminDomain;
+import com.moment.the.admin.repository.AdminRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+
+@Aspect
+@Component
+@Slf4j
+public class AdminLoginAop {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    private AdminDomain testSignUp(){
+        AdminDomain adminDomain = AdminDomain.builder()
+                .email(RandomStringUtils.randomAlphabetic(5))
+                .password(RandomStringUtils.randomAlphabetic(5))
+                .name(RandomStringUtils.randomAlphabetic(5))
+                .roles(Collections.singletonList("ROLE_ADMIN"))
+                .build();
+
+        return adminRepository.save(adminDomain);
+    }
+
+    private AdminDomain testSignIn(String adminId, String password) {
+        AdminDomain adminDomain = adminRepository.findByEmailAndPassword(adminId, password);
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                adminDomain.getEmail(),
+                adminDomain.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+
+        return adminDomain;
+    }
+
+
+    @Before(value = "execution(* com.moment.the.util.*(..))")
+    public void signUpSignInTest(ProceedingJoinPoint pjp) throws Throwable {
+        log.info("========== job start {}=========", LocalDateTime.now());
+
+        AdminDomain signUpAdmin = testSignUp();
+        AdminDomain adminDomain = testSignIn(signUpAdmin.getEmail(), signUpAdmin.getPassword());
+
+        Object proceed = pjp.proceed();
+
+        log.info("========== job finish {}=========", LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
+++ b/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
@@ -4,9 +4,7 @@ import com.moment.the.admin.AdminDomain;
 import com.moment.the.admin.repository.AdminRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,10 +12,8 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-
 
 @Aspect
 @Component

--- a/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
+++ b/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
@@ -4,7 +4,6 @@ import com.moment.the.admin.AdminDomain;
 import com.moment.the.admin.repository.AdminRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
-@Aspect
 @Component
 @Slf4j
 public class AdminTestUtil {

--- a/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
+++ b/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
@@ -14,6 +14,12 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * 테스트에서 빈번히 발생하는 작업에 대해 Bean으로 등록하여 사용할 수 있습니다.
+ *
+ * @since 1.3.1
+ * @author 전지환
+ */
 @Component
 @Slf4j
 public class AdminTestUtil {
@@ -45,6 +51,13 @@ public class AdminTestUtil {
         return adminDomain;
     }
 
+    /**
+     * 회원 가입/로그인이 필요한 테스트케이스에서 사용할 수 있습니다. <br>
+     * 해당 메소드는 로그인까지 지원합니다.
+     *
+     * @return adminId - 로그인 된 adminId
+     * @author 전지환
+     */
     public Long signUpSignInTest() {
         AdminDomain signUpAdmin = testSignUp();
         log.info("========== join success! ==========");

--- a/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
+++ b/src/test/java/com/moment/the/testConfig/AdminTestUtil.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Aspect
 @Component
 @Slf4j
-public class AdminLoginAop {
+public class AdminTestUtil {
 
     @Autowired
     private AdminRepository adminRepository;
@@ -51,16 +51,13 @@ public class AdminLoginAop {
         return adminDomain;
     }
 
-
-    @Before(value = "execution(* com.moment.the.util.*(..))")
-    public void signUpSignInTest(ProceedingJoinPoint pjp) throws Throwable {
-        log.info("========== job start {}=========", LocalDateTime.now());
-
+    public Long signUpSignInTest() {
         AdminDomain signUpAdmin = testSignUp();
+        log.info("========== join success! ==========");
+
         AdminDomain adminDomain = testSignIn(signUpAdmin.getEmail(), signUpAdmin.getPassword());
+        log.info("========== login success! ==========");
 
-        Object proceed = pjp.proceed();
-
-        log.info("========== job finish {}=========", LocalDateTime.now());
+        return adminDomain.getAdminIdx();
     }
 }

--- a/src/test/java/com/moment/the/util/AppUtilTest.java
+++ b/src/test/java/com/moment/the/util/AppUtilTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class AppUtilTest {
+  
+}

--- a/src/test/java/com/moment/the/util/AppUtilTest.java
+++ b/src/test/java/com/moment/the/util/AppUtilTest.java
@@ -1,4 +1,30 @@
+package com.moment.the.util;
+
+import com.moment.the.admin.AdminDomain;
+import com.moment.the.testConfig.AdminTestUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
 class AppUtilTest {
-  
+
+    @Autowired
+    private AppUtil appUtil;
+    @Autowired
+    private AdminTestUtil adminTestUtil;
+
+    @Test
+    @DisplayName("현재 AdminEntity 가져오기")
+    void getCurrentAdminEntityTest(){
+        Long loginAdminId = adminTestUtil.signUpSignInTest();
+        AdminDomain currentAdminEntity = appUtil.getCurrentAdminEntity();
+
+        assertEquals(loginAdminId, currentAdminEntity.getAdminIdx());
+    }
 }


### PR DESCRIPTION
## 개요
* 현재 회원 엔티티/이메일 가져오기 Util 클래스를 작성했습니다.
* 해당 Util 클래스 테스트코드를 작성

## 참고
회원 가입/로그인이 필요한 테스트 케이스에 대하여 매번 `@BeforeEach` 메서드를 만들어야 하는 불편함을 개선하기 위해
테스트 AOP 를 적용시켜 각각의 테스트 케이스 job 실행 전에 AOP로 등록한 메서드를 추가하여 실행하게끔 하려 했지만.

AOP는 해당 클래스의 빈이 생성될 때 프록시를 자동으로 만드는 기술이라..
테스트 클래스에는 적용이 안된다는 결론을 내려 우선 해당 아이디어는 배제하고 다른 방안을 생각중에 있습니다. `AdminTestUtil.java` 로 임시 대체 

## 리뷰 
* 더 추가하고 싶은 Util 메소드 기능제안
* 효율적인 테스트케이스 작성에 대한 의견