### PR TITLE
Update swagger-ui.html config

### DIFF
--- a/src/main/java/com/moment/the/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/moment/the/config/swagger/SwaggerConfig.java
@@ -13,20 +13,20 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
 @EnableSwagger2
-@Profile("dev")
+@Profile({"default", "dev"})
 public class SwaggerConfig {
 
     private ApiInfo apiInfo() {
         return new ApiInfoBuilder()
-                .title("the_moment")
-                .description("the_moment")
+                .title("k2-server")
+                .description("themoment-team, k2-server swagger")
                 .build();
     }
 
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.SWAGGER_2)
-                .groupName("the_moment")
+                .groupName("k2-server")
                 .apiInfo(this.apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors


### PR DESCRIPTION
docker image 설정이 default 프로필로 되어 있어요.
default 프로필은 swagger 와 인메모리 h2 DB 를 사용해요 !

기존에 swagger ui 경로가 disable 되어 있어서 사용 가능하도록 바꾸었어요!