### PR TITLE
Test/local date static method

### DIFF
--- a/src/main/java/com/moment/the/meta/service/MetaService.java
+++ b/src/main/java/com/moment/the/meta/service/MetaService.java
@@ -7,13 +7,45 @@ import java.time.temporal.ChronoUnit;
 
 @Service
 public class MetaService {
+
+    /**
+     * Use spring PSA:: static method mockito로 테스트하기 까다롭다.
+     *
+     * @author 전지환
+     */
+    @Service
+    interface LocalDateService {
+        LocalDate getLocalDateNow();
+        LocalDate getReleaseDate();
+    }
+
+    @Service
+    static class MetaLocalDateService implements LocalDateService{
+        @Override
+        public LocalDate getLocalDateNow() {
+            return LocalDate.now();
+        }
+
+        @Override
+        public LocalDate getReleaseDate() {
+            return LocalDate.of(2021, 6, 7);
+        }
+    }
+
+    private final LocalDateService localDateService;
+
+    // LocalDateService로 추상화 타입을 잡고 MetaLocalDateService를 주입한다.
+    public MetaService(MetaLocalDateService metaLocalDateService) {
+        this.localDateService = metaLocalDateService;
+    }
+
     /**
      * 오늘을 기준으로 프로젝트 시행 기간을 가져온다.
      *
      * @return int - termProjectStart
      */
     public int getTermProjectStart(){
-        return calculateAfterDate(LocalDate.now());
+        return calculateAfterDate(localDateService.getLocalDateNow());
     }
 
     /**
@@ -22,11 +54,11 @@ public class MetaService {
      * @param today 오늘 날짜
      * @return int - D-day after
      */
-    public static int calculateAfterDate(LocalDate today) {
-        //  theMomentStart: the-moment 시작 날짜
-        LocalDate theMomentStart = LocalDate.of(2021, 6, 7);
+    private int calculateAfterDate(LocalDate today) {
+        //  releaseDate: every-moment 출시일
+        final LocalDate releaseDate = localDateService.getReleaseDate();
 
-        // the_moment 프로젝트를 시작한 날짜 by 오늘의 날짜
-        return (int) theMomentStart.until(today, ChronoUnit.DAYS);
+        // every-moment 출시일 by 오늘
+        return (int) releaseDate.until(today, ChronoUnit.DAYS);
     }
 }

--- a/src/test/java/com/moment/the/meta/service/MetaServiceTest.java
+++ b/src/test/java/com/moment/the/meta/service/MetaServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MetaServiceTest {
+  
+}

--- a/src/test/java/com/moment/the/meta/service/MetaServiceTest.java
+++ b/src/test/java/com/moment/the/meta/service/MetaServiceTest.java
@@ -1,4 +1,38 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.moment.the.meta.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+@Slf4j
 class MetaServiceTest {
-  
+
+    @Autowired
+    private MetaService metaService;
+
+    @Autowired
+    private MetaService.LocalDateService metaLocalDateService;
+
+    @Test
+    @DisplayName("MetaService_getTermProjectStart()는 calculateAfterDate()에서 계산된 값을 정상적으로 리턴한다.")
+    void metaService_getTermProjectStart_test(){
+        final LocalDate localDateNow = metaLocalDateService.getLocalDateNow();
+
+        final Integer calculateAfterDateValue = ReflectionTestUtils.invokeMethod(metaService, "calculateAfterDate", localDateNow);
+        final int termProjectStartValue = metaService.getTermProjectStart();
+
+        log.info("====== private calculateAfterDate() value: {} ============= real business logic: {} ", calculateAfterDateValue, termProjectStartValue);
+        assertEquals(calculateAfterDateValue, termProjectStartValue);
+    }
+
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
`LocalDate.now()`, `LocalDate.of()` static method를 테스트 하는데 어려움이 있다.

- 기존
기존에는 `Mockito.mockStatic()` 을 사용해서 테스트 했는데..
mockStatic은 한 테스트에 대해서 1회성이다. 이유는`try~resource` 안에 `try-resource`를 써서 `LocalDate` 클래스 2개의 static method를 테스트 하기에는 부적절한 방법이라고 한다.

- 변경
마침 제가 제일 고민하던 주제를 올렸더라고요 [-> 백기선의 PSA](https://youtu.be/bJfbPWEMj_c)
스프링 3대 핵심 원리 중 하나인 PSA 원리를 이용하여 구성하였습니다.
이렇게 하면 Mocking 라이브러리를 쓰지 않고도 바람직하게 해결할 수 있다고 합니다.

또, 해당 LocalDateService는 MetaService 에서만 사용하고 있어 inner interface, inner class 로 배치했습니다.
(지금은 이 방식이 코드 가독성을 높이는 것 같습니다.) 나중에 확장이 필요할 때 따로 분리할 생각입니다.

## 어떻게 해결했나요?
* Spring PSA
* client는 추상화 타입을 갖고 구체 타입은 생성자 주입을 통해 활성화

## Attachment
<img width="673" alt="Screen Shot 2022-02-10 at 1 18 22 AM" src="https://user-images.githubusercontent.com/67095821/153246638-91ae6bf5-9f70-4f9a-9262-ae240c18f6e4.png">

## 리뷰해주세요 🙇🏻‍♂️
* PR
